### PR TITLE
Fix build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./build/bin/${{ env.APPNAME }}_${{ env.VERSION }}_${{ env.OS_LOWER }}_${{ env.ARCH_LOWER }}
-          asset_name: ${{ env.APPNAME }_${{ env.OS_LOWER }}_${{ env.ARCH_LOWER }}
+          asset_name: ${{ env.APPNAME }}_${{ env.OS_LOWER }}_${{ env.ARCH_LOWER }}
           asset_content_type: application/octet-stream
 
   notify_download_server:


### PR DESCRIPTION
## Summary
- fix syntax for asset_name in build-and-release workflow

## Testing
- `go fmt ./...` *(fails: directory prefix '.' does not contain main module)*
- `go vet ./...` *(fails: directory prefix '.' does not contain main module)*
- `go test ./...` *(fails: directory prefix '.' does not contain main module)*
- `cd app && go fmt ./...` *(fails due to toolchain download: Forbidden)*
- `go vet ./...` *(fails due to toolchain download: Forbidden)*
- `go test ./...` *(fails due to toolchain download: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684af84715108330a8b752f09eb4af0f