### PR TITLE
Add make targets for fmt/vet/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,16 @@ update-pocketbase:
 	cd $(MAKEFILE_DIR)app && $(GO_BIN) get github.com/pocketbase/pocketbase@latest
 	cd $(MAKEFILE_DIR)app && $(GO_BIN) mod tidy
 	echo "PocketBase updated."
+
+
+.PHONY: fmt
+fmt: $(GO_BIN)
+	cd $(MAKEFILE_DIR)app && $(GO_BIN) fmt ./...
+
+.PHONY: vet
+vet: $(GO_BIN)
+	cd $(MAKEFILE_DIR)app && $(GO_BIN) vet ./...
+
+.PHONY: test
+test: $(GO_BIN)
+	cd $(MAKEFILE_DIR)app && $(GO_BIN) test ./...

--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ A Makefile is included to manage the Go toolchain and compile the project.
 - Migration files live in `app/migrations` and are automatically registered.
 - Use `make clean` to remove build artifacts.
 - Run `make update-pocketbase` to fetch the latest PocketBase version.
+- Run `make fmt` to format the code and `make vet` to perform static analysis.
 
 The Makefile downloads the Go toolchain defined in `Makefile`, so you do not need Go installed globally.


### PR DESCRIPTION
## Summary
- add `fmt`, `vet`, and `test` targets that run with the local toolchain
- document formatting and vetting commands in the README

## Testing
- `make fmt`
- `make vet` *(fails: modernc.org/sqlite download Forbidden)*
- `make test` *(fails: modernc.org/sqlite download Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b1b2023108330854706c95988003a